### PR TITLE
feat: implement user registration API

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "vibe-coding",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
         "dotenv": "latest",
         "drizzle-orm": "latest",
         "elysia": "latest",
@@ -85,6 +86,8 @@
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
+
+    "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "db:studio": "bunx drizzle-kit studio"
   },
   "dependencies": {
-    "drizzle-orm": "latest",
+    "bcryptjs": "^3.0.3",
     "dotenv": "latest",
+    "drizzle-orm": "latest",
     "elysia": "latest",
     "mysql2": "latest"
   },

--- a/src/db/schema.js
+++ b/src/db/schema.js
@@ -4,5 +4,7 @@ export const users = mysqlTable('users', {
   id: int('id').primaryKey().autoincrement(),
   name: varchar('name', { length: 255 }).notNull(),
   email: varchar('email', { length: 255 }).notNull().unique(),
+  password: varchar('password', { length: 255 }).notNull(),
   createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow().onUpdateNow(),
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,14 @@
 import 'dotenv/config';
 import { Elysia } from 'elysia';
 import { userRoutes } from './routes/user.js';
+import { usersRoutes } from './routes/users-routes.js';
 
 const PORT = process.env.PORT || 3000;
 
 const app = new Elysia()
   .get('/', () => ({ message: 'API is running 🦊' }))
   .use(userRoutes)
+  .use(usersRoutes)
   .listen(PORT);
 
 console.log(`🦊 Elysia is running at http://localhost:${PORT}`);

--- a/src/routes/users-routes.js
+++ b/src/routes/users-routes.js
@@ -1,0 +1,23 @@
+import { Elysia, t } from 'elysia';
+import { registerUser } from '../services/users-service.js';
+
+export const usersRoutes = new Elysia({ prefix: '/api' })
+  .post('/users', async ({ body, set }) => {
+    try {
+      await registerUser(body);
+      return { data: 'OK' };
+    } catch (error) {
+      if (error.message === 'Email already exists') {
+        set.status = 400;
+        return { error: 'Email already exists' };
+      }
+      set.status = 500;
+      return { error: 'Internal Server Error' };
+    }
+  }, {
+    body: t.Object({
+      name: t.String(),
+      email: t.String(),
+      password: t.String()
+    })
+  });

--- a/src/services/users-service.js
+++ b/src/services/users-service.js
@@ -1,0 +1,25 @@
+import { db } from '../db/index.js';
+import { users } from '../db/schema.js';
+import { eq } from 'drizzle-orm';
+import bcrypt from 'bcryptjs';
+
+export const registerUser = async ({ name, email, password }) => {
+  // Check if email already exists
+  const existingUser = await db.select().from(users).where(eq(users.email, email)).limit(1);
+  
+  if (existingUser.length > 0) {
+    throw new Error('Email already exists');
+  }
+
+  // Hash password
+  const hashedPassword = await bcrypt.hash(password, 10);
+
+  // Insert new user
+  await db.insert(users).values({
+    name,
+    email,
+    password: hashedPassword,
+  });
+
+  return { success: true };
+};


### PR DESCRIPTION
Implement user registration with email check and password hashing as per issue #4.

Changes:
- Added password and updatedAt columns to users table.
- Created users-service.js for registration logic.
- Created users-routes.js for API endpoint POST /api/users.
- Registered new routes in src/index.js.
- Installed bcryptjs for secure password hashing.