### PR TITLE
chore: remove .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,0 @@
-DATABASE_URL=mysql://root:password@localhost:3306/vibe_coding
-PORT=3000


### PR DESCRIPTION
Remove .env.example file as it is no longer needed.