### PR TITLE
feat: implement get current user API

### DIFF
--- a/src/routes/users-routes.js
+++ b/src/routes/users-routes.js
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { registerUser, loginUser } from '../services/users-service.js';
+import { registerUser, loginUser, getCurrentUser } from '../services/users-service.js';
 
 export const usersRoutes = new Elysia({ prefix: '/api' })
   .post('/users', async ({ body, set }) => {
@@ -38,4 +38,24 @@ export const usersRoutes = new Elysia({ prefix: '/api' })
       email: t.String(),
       password: t.String()
     })
+  })
+  .get('/users/current', async ({ headers, set }) => {
+    try {
+      const authHeader = headers.authorization;
+      if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        set.status = 401;
+        return { error: 'Unauthorized' };
+      }
+
+      const token = authHeader.split(' ')[1];
+      const user = await getCurrentUser(token);
+      return { data: user };
+    } catch (error) {
+      if (error.message === 'Unauthorized') {
+        set.status = 401;
+        return { error: 'Unauthorized' };
+      }
+      set.status = 500;
+      return { error: 'Internal Server Error' };
+    }
   });

--- a/src/services/users-service.js
+++ b/src/services/users-service.js
@@ -57,3 +57,25 @@ export const loginUser = async ({ email, password }) => {
     },
   };
 };
+
+export const getCurrentUser = async (token) => {
+  const result = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      createdAt: users.createdAt,
+    })
+    .from(sessions)
+    .innerJoin(users, eq(sessions.userId, users.id))
+    .where(eq(sessions.token, token))
+    .limit(1);
+
+  const user = result[0];
+
+  if (!user) {
+    throw new Error('Unauthorized');
+  }
+
+  return user;
+};


### PR DESCRIPTION
Implement API to get current logged-in user profile using Bearer token as per issue #9.

Changes:
- Added getCurrentUser function to users-service.js (Join sessions with users).
- Added GET /api/users/current endpoint to users-routes.js.